### PR TITLE
Add support to specify resources protocol

### DIFF
--- a/cmd/add-resources.go
+++ b/cmd/add-resources.go
@@ -59,8 +59,9 @@ var resourcesAddCmd = &cobra.Command{
 					func(s string) { resource.PublicHost = s },
 					func(s string) { resource.InternalHost = s },
 					func(s []string) {
-						resource.PortMappings = []*models.AccessResourcePortMapping{
-							colonMappingsToPortMappings(s),
+						resource.PortMappings = []*models.AccessResourcePortMapping{}
+						for _, mapping := range s {
+							resource.PortMappings = append(resource.PortMappings, colonMappingToPortMapping(mapping))
 						}
 					},
 					func(s string) { resource.AccessProxyID = strfmt.UUID(s) },
@@ -95,17 +96,26 @@ var resourcesAddCmd = &cobra.Command{
 	},
 }
 
-func colonMappingsToPortMappings(mappings []string) *models.AccessResourcePortMapping {
-	publicPorts := make([]string, len(mappings))
-	internalPorts := make([]string, len(mappings))
-	for i, mapping := range mappings {
-		parts := strings.SplitN(mapping, ":", 2)
-		publicPorts[i] = strings.TrimSpace(parts[0])
-		internalPorts[i] = strings.TrimSpace(parts[len(parts)-1])
+func colonMappingToPortMapping(mapping string) *models.AccessResourcePortMapping {
+	var protocol string
+	internalPorts := []string{}
+	parts := strings.SplitN(mapping, ":", 3)
+	publicPorts := strings.Split(strings.TrimSpace(parts[0]), ",")
+
+	if len(parts) > 1 {
+		internalPorts = strings.Split(strings.TrimSpace(parts[1]), ",")
 	}
+
+	if len(parts) > 2 {
+		protocol = strings.TrimSpace(parts[2])
+	} else {
+		protocol = "tcp"
+	}
+
 	return &models.AccessResourcePortMapping{
-		PublicPorts:   publicPorts,
 		InternalPorts: internalPorts,
+		PublicPorts:   publicPorts,
+		Protocol:      protocol,
 	}
 }
 
@@ -155,8 +165,8 @@ func init() {
 		inputField{
 			Name:            "Port mappings",
 			FlagName:        "ports",
-			FlagDescription: "specify the port mappings (external:internal) for the created resource",
-			VarType:         "[]string",
+			FlagDescription: "specify the port mappings (external:internal:protocol) for the created resource. Also accepts (external:internal), considers TCP by default.",
+			VarType:         "[]string.skipcomma",
 			Mandatory:       true,
 			DefaultValue:    []string{},
 		},

--- a/cmd/common-filtering.go
+++ b/cmd/common-filtering.go
@@ -56,6 +56,8 @@ func initFilterFlags(cmd *cobra.Command, filterTypes ...filterType) {
 			cmd.Flags().StringSlice(name, []string{}, desc)
 		case "[]string":
 			cmd.Flags().StringSlice(name, []string{}, desc)
+		case "[]string.skipcomma":
+			cmd.Flags().StringArray(name, []string{}, desc)
 		default:
 			panic("Unknown filter variable type " + filterType.vartype)
 		}

--- a/cmd/common-input.go
+++ b/cmd/common-input.go
@@ -98,6 +98,8 @@ func initInputFlags(cmd *cobra.Command, typeName string, fields ...inputField) {
 			cmd.Flags().StringSliceP(field.FlagName, field.FlagShorthand, dconv, field.FlagDescription)
 		case "[]string":
 			cmd.Flags().StringSliceP(field.FlagName, field.FlagShorthand, field.DefaultValue.([]string), field.FlagDescription)
+		case "[]string.skipcomma":
+			cmd.Flags().StringArrayP(field.FlagName, field.FlagShorthand, field.DefaultValue.([]string), field.FlagDescription)
 		default:
 			panic("Unknown filter variable type " + field.VarType)
 		}
@@ -175,6 +177,8 @@ func getFlagValue(cmd *cobra.Command, varType, flagName string) (interface{}, er
 		return out, nil
 	case "[]string":
 		value, err = cmd.Flags().GetStringSlice(flagName)
+	case "[]string.skipcomma":
+		value, err = cmd.Flags().GetStringArray(flagName)
 	default:
 		panic("Unknown variable type " + varType)
 	}
@@ -437,7 +441,7 @@ func forAllInputFromCSV(cmd *cobra.Command,
 			if strings.ToLower(header[i]) == "port_mappings" ||
 				strings.ToLower(header[i]) == "portmappings" {
 				m[header[i]] = []*models.AccessResourcePortMapping{
-					colonMappingsToPortMappings(commaSeparatedListToStringSlice(record[i])),
+					colonMappingToPortMapping(strings.TrimRight(strings.TrimLeft(record[i], "["), "]")),
 				}
 			} else {
 				m[header[i]] = record[i]

--- a/cmd/edit-resources.go
+++ b/cmd/edit-resources.go
@@ -64,8 +64,9 @@ var resourcesEditCmd = &cobra.Command{
 					func(s string) { resource.PublicHost = s },
 					func(s string) { resource.InternalHost = s },
 					func(s []string) {
-						resource.PortMappings = []*models.AccessResourcePortMapping{
-							colonMappingsToPortMappings(s),
+						resource.PortMappings = []*models.AccessResourcePortMapping{}
+						for _, mapping := range s {
+							resource.PortMappings = append(resource.PortMappings, colonMappingToPortMapping(mapping))
 						}
 					},
 					func(s string) { resource.AccessProxyID = strfmt.UUID(s) },
@@ -160,8 +161,8 @@ func init() {
 		inputField{
 			Name:            "Port mappings",
 			FlagName:        "ports",
-			FlagDescription: "specify the new port mappings (external:internal) for the resource",
-			VarType:         "[]string",
+			FlagDescription: "specify the port mappings (external:internal:protocol) for the created resource. Also accepts (external:internal), considers TCP by default.",
+			VarType:         "[]string.skipcomma",
 			Mandatory:       false,
 			DefaultValue:    []string{},
 		},

--- a/swagger.yml
+++ b/swagger.yml
@@ -2610,6 +2610,8 @@ definitions:
       label:
         type: string
         example: "Example mapping"
+      protocol:
+        enum: [tcp, udp, both]
       public_ports:
         type: array
         items:


### PR DESCRIPTION
Allows user to specity if he wants tcp/udp/both ports on the resource specification.

Also allows user to specify multiple port definitions, similarly to the UI.﻿
