### PR TITLE
Scope user APIs to tenant

### DIFF
--- a/cmd/add-users.go
+++ b/cmd/add-users.go
@@ -63,6 +63,7 @@ var usersAddCmd = &cobra.Command{
 				}
 				body := apiusers.CreateUserBody{User: user}
 				params := apiusers.NewCreateUserParams()
+				setTenant(cmd, params)
 				params.SetUser(body)
 
 				resp, err := global.Client.Users.CreateUser(params, global.AuthWriter)
@@ -97,6 +98,7 @@ func init() {
 
 	initOutputFlags(usersAddCmd)
 	initLoopControlFlags(usersAddCmd)
+	initTenantFlags(usersAddCmd)
 
 	initInputFlags(usersAddCmd, "user",
 		inputField{

--- a/cmd/common-tenant.go
+++ b/cmd/common-tenant.go
@@ -1,0 +1,46 @@
+// Package cmd implements fyde-cli commands
+package cmd
+
+/*
+Copyright © 2019 Fyde, Inc. <hello@fyde.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/spf13/cobra"
+)
+
+type tenantable interface {
+	SetTenantID(tenant strfmt.UUID)
+}
+
+func initTenantFlags(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[flagInitTenant] = "yes"
+	cmd.Flags().StringP("tenant", "t", "", "tenant ID to perform operation on")
+}
+
+func setTenant(cmd *cobra.Command, t tenantable) {
+	if _, ok := cmd.Annotations[flagInitTenant]; !ok {
+		panic("setTenant called for command where tenant flag was not initialized. This is a bug!")
+	}
+	tenant, err := cmd.Flags().GetString("tenant")
+	if err != nil || tenant == "" {
+		tenant = global.CurrentTenant
+	}
+	t.SetTenantID(strfmt.UUID(tenant))
+}

--- a/cmd/delete-user.go
+++ b/cmd/delete-user.go
@@ -55,6 +55,7 @@ var userDeleteCmd = &cobra.Command{
 
 		delete := func(ids []int64) error {
 			params := apiusers.NewDeleteUserParams()
+			setTenant(cmd, params)
 			params.SetID(ids)
 
 			_, err = global.Client.Users.DeleteUser(params, global.AuthWriter)
@@ -110,4 +111,5 @@ func init() {
 	initMultiOpArgFlags(userDeleteCmd, "user", "delete", "id", "[]int64")
 	initOutputFlags(userDeleteCmd)
 	initLoopControlFlags(userDeleteCmd)
+	initTenantFlags(userDeleteCmd)
 }

--- a/cmd/edit-users.go
+++ b/cmd/edit-users.go
@@ -50,6 +50,7 @@ var usersEditCmd = &cobra.Command{
 			func(values *inputEntry) (interface{}, error) { // do func
 				total++ // this is the total of successful+failures, must increment before failure
 				params := apiusers.NewEditUserParams()
+				setTenant(cmd, params)
 				// IDs are not part of the request body, so we use this workaround
 				enabledDefault := true
 				user := &struct {
@@ -107,6 +108,7 @@ func init() {
 
 	initOutputFlags(usersEditCmd)
 	initLoopControlFlags(usersEditCmd)
+	initTenantFlags(usersEditCmd)
 
 	initInputFlags(usersEditCmd, "user",
 		inputField{

--- a/cmd/enable-disable-user.go
+++ b/cmd/enable-disable-user.go
@@ -59,6 +59,7 @@ var userEnableCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewEditUserParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 			params.SetUser(apiusers.EditUserBody{
 				User: &apiusers.EditUserParamsBodyUser{
@@ -110,4 +111,7 @@ func init() {
 
 	initLoopControlFlags(userEnableCmd)
 	initLoopControlFlags(userDisableCmd)
+
+	initTenantFlags(userEnableCmd)
+	initTenantFlags(userDisableCmd)
 }

--- a/cmd/get-user.go
+++ b/cmd/get-user.go
@@ -67,6 +67,7 @@ var userGetCmd = &cobra.Command{
 		}
 
 		params := apiusers.NewGetUserParams()
+		setTenant(cmd, params)
 		params.SetID(userID)
 
 		resp, err := global.Client.Users.GetUser(params, global.AuthWriter)
@@ -151,5 +152,7 @@ func init() {
 	// userGetCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
 	initOutputFlags(userGetCmd)
+	initTenantFlags(userGetCmd)
+
 	userGetCmd.Flags().Int("id", 0, "id of user to get")
 }

--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -46,6 +46,7 @@ var usersListCmd = &cobra.Command{
 		setSort(cmd, params)
 		setFilter(cmd, params.SetGroupID, params.SetGroupName, params.SetStatus, params.SetEnrollmentStatus)
 		setSearchQuery(cmd, params)
+		setTenant(cmd, params)
 		completePayload := []*apiusers.ListUsersOKBodyItems0{}
 		total := 0
 		cutStart, cutEnd, err := forAllPages(cmd, params, func() (int, int64, error) {
@@ -92,6 +93,7 @@ func init() {
 		filterType{"group-name", "[]string"},
 		filterType{"enabled-status", "string"},
 		filterType{"status", "string"})
+	initTenantFlags(usersListCmd)
 	initSearchFlags(usersListCmd)
 	initOutputFlags(usersListCmd)
 }

--- a/cmd/user-enrollment.go
+++ b/cmd/user-enrollment.go
@@ -77,6 +77,7 @@ var enrollmentGenerateCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewGenerateEnrollmentLinkParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 
 			resp, err := global.Client.Users.GenerateEnrollmentLink(params, global.AuthWriter)
@@ -129,6 +130,7 @@ var enrollmentRevokeCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewRevokeEnrollmentLinkParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 
 			_, err = global.Client.Users.RevokeEnrollmentLink(params, global.AuthWriter)
@@ -193,6 +195,7 @@ var enrollmentChangeCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewChangeEnrollmentLinkSlotsParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 
 			enrollment := &apiusers.ChangeEnrollmentLinkSlotsParamsBodyEnrollment{
@@ -254,6 +257,7 @@ var enrollmentGetCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewGetUserParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 
 			resp, err := global.Client.Users.GetUser(params, global.AuthWriter)
@@ -293,6 +297,7 @@ var enrollmentEmailCmd = &cobra.Command{
 
 		for _, arg := range intArgs {
 			params := apiusers.NewSendEnrollmentEmailParams()
+			setTenant(cmd, params)
 			params.SetID(arg)
 
 			_, err = global.Client.Users.SendEnrollmentEmail(params, global.AuthWriter)
@@ -337,20 +342,25 @@ func init() {
 	initMultiOpArgFlags(enrollmentGenerateCmd, "user", "generate enrollments for", "id", "[]int64")
 	initOutputFlags(enrollmentGenerateCmd)
 	initLoopControlFlags(enrollmentGenerateCmd)
+	initTenantFlags(enrollmentGenerateCmd)
 
 	initMultiOpArgFlags(enrollmentRevokeCmd, "user", "revoke enrollments for", "id", "[]int64")
 	initOutputFlags(enrollmentRevokeCmd)
 	initLoopControlFlags(enrollmentRevokeCmd)
+	initTenantFlags(enrollmentRevokeCmd)
 
 	initMultiOpArgFlags(enrollmentChangeCmd, "user", "change enrollments for", "id", "[]int64")
 	enrollmentChangeCmd.Flags().Int("slots", 0, "specify the new number of slots for the enrollment link")
 	initOutputFlags(enrollmentChangeCmd)
 	initLoopControlFlags(enrollmentChangeCmd)
+	initTenantFlags(enrollmentChangeCmd)
 
 	initMultiOpArgFlags(enrollmentGetCmd, "user", "get enrollments for", "id", "[]int64")
 	initLoopControlFlags(enrollmentGetCmd)
+	initTenantFlags(enrollmentGetCmd)
 
 	initMultiOpArgFlags(enrollmentEmailCmd, "user", "send enrollment emails", "id", "[]int64")
 	initOutputFlags(enrollmentEmailCmd)
 	initLoopControlFlags(enrollmentEmailCmd)
+	initTenantFlags(enrollmentEmailCmd)
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -169,7 +169,7 @@ paths:
       responses:
         200:
           description: "successful operation"
-  /users:
+  /tenants/{tenant_id}/users:
     get:
       tags:
       - "users"
@@ -206,6 +206,7 @@ paths:
         collectionFormat: multi
         items:
           type: integer
+      - $ref: '#/parameters/tenantIdParam'
       - $ref: '#/parameters/sortParam'
       - $ref: '#/parameters/pageParam'
       - $ref: '#/parameters/perPageParam'
@@ -229,6 +230,8 @@ paths:
                     example: 2
         401:
           $ref: "#/responses/Unauthorized"
+        404:
+          $ref: "#/responses/NotFound"
     post:
       tags:
         - "users"
@@ -266,6 +269,7 @@ paths:
                   type: string
                 send_email_invitation:
                   type: boolean
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         201:
           description: "User created"
@@ -281,9 +285,11 @@ paths:
                       type: object
         401:
           $ref: "#/responses/Unauthorized"
+        404:
+          $ref: "#/responses/NotFound"
         422:
           $ref: "#/responses/UnprocessableEntity"
-  /users/{id}:
+  /tenants/{tenant_id}/users/{id}:
     get:
       tags:
         - "users"
@@ -297,6 +303,7 @@ paths:
         required: true
         type: integer
         description: "The ID of the user to retrieve"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         200:
           description: "User info"
@@ -357,6 +364,7 @@ paths:
                   example: "John Doe"
                 phone_number:
                   type: string
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         200:
           description: "User edited"
@@ -392,6 +400,7 @@ paths:
         items:
           type: integer
         description: "The IDs of the users to delete, comma-separated"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         204:
           description: "User deleted"
@@ -401,7 +410,7 @@ paths:
           $ref: "#/responses/NotFound"
         422:
           $ref: "#/responses/UnprocessableEntity"
-  /users/{id}/enrollment:
+  /tenants/{tenant_id}/users/{id}/enrollment:
     post:
       tags:
         - "users"
@@ -413,6 +422,7 @@ paths:
         required: true
         type: integer
         description: "The ID of the user for which to generate a enrollment link"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         201:
           description: "Enrollment link created"
@@ -460,6 +470,7 @@ paths:
                 refcount:
                   type: integer
                   description: "The desired number of slots"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         200:
           description: "Enrollment link changed"
@@ -493,6 +504,7 @@ paths:
         required: true
         type: integer
         description: "The ID of the user for which to revoke the enrollment link"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         204:
           description: "Enrollment link revoked"
@@ -502,7 +514,7 @@ paths:
           $ref: "#/responses/Forbidden"
         404:
           $ref: "#/responses/NotFound"
-  /users/{id}/send_enrollment_email:
+  /tenants/{tenant_id}/users/{id}/send_enrollment_email:
     post:
       tags:
         - "users"
@@ -516,12 +528,13 @@ paths:
         required: true
         type: integer
         description: "The ID of the user for which to send the email"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         204:
           description: "Email sent"
         422:
           $ref: "#/responses/UnprocessableEntity"
-  /users/{user_id}/devices/{device_id}:
+  /tenants/{tenant_id}/users/{user_id}/devices/{device_id}:
     delete:
       tags:
         - "devices"
@@ -540,6 +553,7 @@ paths:
         type: string
         format: uuid
         description: "The ID of the device to delete"
+      - $ref: '#/parameters/tenantIdParam'
       responses:
         204:
           description: "Device deleted"
@@ -2319,6 +2333,13 @@ security:
     accessToken: []
     client: []
 parameters:
+  tenantIdParam:
+    in: path
+    name: "tenant_id"
+    required: true
+    type: string
+    format: uuid
+    description: "The ID of the tenant"
   sortParam:
     in: query
     name: sort
@@ -2378,6 +2399,10 @@ definitions:
           tenant_id:
             type: string
             format: uuid
+          tenant_name:
+            type: string
+            example: "ACME Corp."
+            description: "Name of default tenant configured for the admin"
           allow_password_change:
             type: boolean
           image:


### PR DESCRIPTION
We have introduced scoped tenant APIs for most entities, since an admin can manipulate more than one.
On login, we assume the returned tenant as the default so that there's no requirement to specify one.﻿
