### PR TITLE
Add maintainer to nfpm based packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ nfpms:
   -
     vendor: Barracuda Networks, Inc.
     homepage: https://campus.barracuda.com/product/cloudgenaccess/doc/93201218/overview/
+    maintainer: Barracuda Networks, Inc. <support@barracuda.com>
     description: Command-line client for CloudGen Access Console APIs
     license: Apache 2.0
     formats:


### PR DESCRIPTION
Add maintainer to avoid annoying warnings like:

`dpkg: warning: parsing file '/var/lib/dpkg/status' near line 46 package 'access-cli':`