### PR TITLE
feat(): Support date range for 'records list'

### DIFF
--- a/cmd/list-records.go
+++ b/cmd/list-records.go
@@ -47,7 +47,7 @@ var recordsListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params := apievents.NewListDeviceEventsParams()
 		setTenant(cmd, params)
-		setFilter(cmd, params.SetEventName, params.SetUserID)
+		setFilter(cmd, params.SetEventName, params.SetUserID, params.SetFromTime, params.SetToTime)
 		completePayload := []*models.DeviceEventListItem{}
 		total := 0
 		cutStart, cutEnd, err := forAllPages(cmd, params, func() (int, int64, error) {
@@ -112,7 +112,10 @@ func init() {
 	initSortFlags(recordsListCmd)
 	initFilterFlags(recordsListCmd,
 		filterType{"event-name", "[]string"},
-		filterType{"user-id", "int"})
+		filterType{"user-id", "int"},
+		filterType{"from-date", "string"},
+		filterType{"to-date", "string"})
+
 	initOutputFlags(recordsListCmd)
 	initTenantFlags(recordsListCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,12 @@ func aliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "range-end"
 	case "format":
 		name = "output"
+	case "from-date":
+		name = "from-time"
+	case "to-date":
+		name = "to-time"
 	}
+
 	return pflag.NormalizedName(name)
 }
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "CloudGen Access Console API docs"
-  version: "1.0.0"
+  version: "1.0.1"
   title: "CloudGen Access Console"
   termsOfService: "https://www.barracuda.com/company/legal/prd_trm"
   contact:
@@ -1876,6 +1876,16 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - in: query
+        name: "from_time"
+        description: "Date Range from date, example: 2023-05-25"
+        required: false
+        type: string
+      - in: query
+        name: "to_time"
+        description: "Date Range to date, example: 2023-06-02"
+        required: false
+        type: string
       - $ref: '#/parameters/pageParam'
       - $ref: '#/parameters/perPageParam'
       - $ref: '#/parameters/tenantIdParam'


### PR DESCRIPTION
provide date range as this: 
--filter-from-date 'yyyy-MM-dd'
--filter-to-date 'yyyy-MM-dd'

i.e: `./access-cli records list --filter-from-date='2023-04-24' --filter-to-date='2023-06-02' --output=json`
